### PR TITLE
Update maxBuffer for CloudFront (#3)

### DIFF
--- a/bin/cloudfront.js
+++ b/bin/cloudfront.js
@@ -6,7 +6,9 @@ const { exec, execSync } = require('child_process');
 const AWS_S3_BUCKET = process.env.AWS_S3_BUCKET;
 const BUILD_DIR = process.env.BUILD_DIR;
 
-exec(`${BUILD_DIR}/bin/aws cloudfront list-distributions`, (err, stdout, stderr) => {
+exec(`${BUILD_DIR}/bin/aws cloudfront list-distributions`, {
+  maxBuffer: 10000*1024
+}, (err, stdout, stderr) => {
   if (err) {
     return console.log(stderr);
   }


### PR DESCRIPTION
Current buffer is 200*1024=200KB (default) that is not enough for our distributions list. I upgrade it to 10MB.